### PR TITLE
fix camptocamp_archive string and version

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -8,4 +8,4 @@ description 'This defined type provides a way to use multiple Elastic Search ins
 project_page 'https://github.com/meltwater/puppet-es'
 
 dependency 'puppetlabs/stdlib', '>= 2.2.0'
-dependency 'camptocamp-archive'
+dependency 'camptocamp/archive', '>= 0.0.1'


### PR DESCRIPTION
This pr fixes an error when using librarian-puppet to fetch puppet modules 

``` shell
salimane at Salimanes-MacBook-Pro  in ~/src/vagrant-kermit/puppet
± librarian-puppet install
/Users/salimane/src/vagrant-kermit/puppet/.tmp/librarian/cache/source/puppet/forge/forgeapi_puppetlabs_com/camptocamp-archive/0.0.1/camptocamp-archive does not exist, something went wrong. Try removing it manually
```

Thanks
