### PR TITLE
Archive depends on $es_path existing.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -93,8 +93,7 @@ define es(
   }
 
   $dirs = [ $es_path, $es_data_path, "${es_path}/plugin_src", $es_log_path ]
-  file { $dirs: ensure => directory }
-
+  file { $dirs: ensure => directory }->
   # Purge any unmanaged file from the plugins directory to ensure that leftover plugin
   # symlinks from previous provisionings are removed (or if their artifact id changes like for multipercolate)
   file { "${es_path}/plugins":
@@ -103,8 +102,7 @@ define es(
     purge   => true,
     recurse => true,
     notify  => Service[$service_name],
-  }
-
+  }->
   archive { "${name}-${version}":
     url            => $es_url,
     target         => $es_path,


### PR DESCRIPTION
Archive will fail if the output directory does not exist. Without chaining here, there is no guarantee that the directory will exist for Archive.

Was failing for me in a Vagrant VM using Ubuntu 14.04
