### PR TITLE
Match a space after the ES path for when you have instances with similar names

### DIFF
--- a/templates/elasticsearch.init.d.erb
+++ b/templates/elasticsearch.init.d.erb
@@ -98,7 +98,7 @@ stop() {
 
 findpid() {
   pid=""
-  pid=$(pgrep -U <%= @user %> -f "<%= @es_path %>.*org.elasticsearch.bootstrap.<%=bootstrapClass%>")
+  pid=$(pgrep -U <%= @user %> -f "<%= @es_path %>\s.*org.elasticsearch.bootstrap.<%=bootstrapClass%>")
 
   # validate output of pgrep
   if ! [ "$pid" = "" ] && ! [ "$pid" -gt 0 ]; then


### PR DESCRIPTION
This recently came up on one node that's configured for two ES instances.

Eg:  instance and instance-master

The default pgrep was matching both instances as the .\* was matching the path for both instances.  Adding a space in the pgrep before the any character match resolves the issue.
