### PR TITLE
Set index_cache_filter_type = 'weighted' as default

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -38,7 +38,7 @@ define es(
   $disable_delete_all_indices = true,
   $indices_cache_filter_size = '10%',
   $indices_fielddata_cache_size = '10%',
-  $indices_fielddata_cache_expire = '5m',
+  $indices_fielddata_cache_expire = '-1',
   $index_cache_filter_type = 'weighted',
   $index_refresh_interval = '60s',
   $cluster_concurrent_rebalance = '768',


### PR DESCRIPTION
This should've been the default since the beginning, this is the default in elasticsearch itself
