### PR TITLE
Allow setting http.cors.enabled through puppet.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -66,6 +66,7 @@ define es(
   # and when adding those two ES would not allow getting things like doc['field'].value without
   # adding java.lang.Object as well
   $script_groovy_sandbox_receiver_whitelist = 'java.lang.Object, org.elasticsearch.common.joda.time.format.DateTimeFormat, org.elasticsearch.common.joda.time.DateTimeZone',
+  $http_cors_enabled = 'true',
 ) {
 
   $es_path  = "${basepath}/${name}"

--- a/templates/elasticsearch.yml.erb
+++ b/templates/elasticsearch.yml.erb
@@ -8,6 +8,7 @@ transport:
 
 http:
         port: <%= @es_http_port_range %>
+        cors.enabled: <%= @http_cors_enabled %>
 
 cluster:
         name: "<%= @clustername %>"


### PR DESCRIPTION
ES 1.4.0 defaults to false compared to 1.3.x
