### PR TITLE
Disable eager filter cache loading which makes nodes go OOM as of es 1.4...

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -41,6 +41,7 @@ define es(
   $indices_fielddata_cache_expire = '-1',
   $index_cache_filter_type = 'weighted',
   $index_refresh_interval = '60s',
+  $index_eager_cache_load = false,
   $cluster_concurrent_rebalance = '768',
   $disable_replica_allocation = false,
   $disable_allocation = false,

--- a/templates/elasticsearch.yml.erb
+++ b/templates/elasticsearch.yml.erb
@@ -55,7 +55,7 @@ indices.fielddata.cache.size: <%= @indices_fielddata_cache_size %>
 indices.fielddata.cache.expire: <%= @indices_fielddata_cache_expire %>
 index.cache.filter.type: <%= @index_cache_filter_type %>
 index.refresh_interval: <%= @index_refresh_interval %>
-index.load_fixed_bitset_filters_eagerly: false
+index.load_fixed_bitset_filters_eagerly: <%= @index_eager_cache_load %>
 
 ## Discovery
 discovery.zen.ping:


### PR DESCRIPTION
....0.

See https://github.com/elasticsearch/elasticsearch/issues/8394
