### PR TITLE
Added action.destructive_requires_name property

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -36,6 +36,7 @@ define es(
   $marvel_exporter_hosts = none,
   $iostore = 'niofs',
   $disable_delete_all_indices = true,
+  $destructive_requires_name = true,
   $indices_cache_filter_size = '10%',
   $indices_fielddata_cache_size = '10%',
   $indices_fielddata_cache_expire = '-1',

--- a/templates/elasticsearch.yml.erb
+++ b/templates/elasticsearch.yml.erb
@@ -90,6 +90,7 @@ indices.recovery.max_bytes_per_sec: <%= @indices_recovery_max_bytes_per_sec %>
 indices.recovery.concurrent_streams: <%= @indices_recovery_concurrent_streams %>
 
 action.disable_delete_all_indices: <%= @disable_delete_all_indices %>
+action.destructive_requires_name: <%= @destructive_requires_name %>
 
 index.query.bool.max_clause_count: <%= @index_query_bool_max_clause_count %>
 


### PR DESCRIPTION
- Makes it illegal to delete indices with wildcards.
  Enabled by default.

This will minimize the risk that anyone deletes indices by accident. Ping @geidies @alexandernilsson 
