### PR TITLE
Add path.repo parameter

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -18,6 +18,7 @@ define es(
   $multicast = true,
   $nodedata = true,
   $nodetag = '',
+  $path_repo = [],
   $spmkey = 'none',
   $spmpath = '/spm/spm-monitor/',
   $spmversion = '1.6.0',

--- a/templates/elasticsearch.yml.erb
+++ b/templates/elasticsearch.yml.erb
@@ -92,6 +92,8 @@ indices.store.throttle.type: <%= @indices_store_throttle_type %>
 indices.recovery.max_bytes_per_sec: <%= @indices_recovery_max_bytes_per_sec %>
 indices.recovery.concurrent_streams: <%= @indices_recovery_concurrent_streams %>
 
+path.repo: <%= @path_repo.inspect %>
+
 action.disable_delete_all_indices: <%= @disable_delete_all_indices %>
 action.destructive_requires_name: <%= @destructive_requires_name %>
 


### PR DESCRIPTION
A snapshot repository has to be registered for storing snapshots. The
repository location must be registered in the path.repo setting on all
master and data nodes. The new path_repo setting makes this easier.