### PR TITLE
Add  option use_original_gc_settings, which enables default gc settings

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -25,6 +25,7 @@ define es(
   $spmversion = '1.6.0',
   $tcpcompress = false,
   $threadpools = false,
+  $use_original_gc_settings = false,
   $user = 'elasticsearch',
   $version = '0.90.3',
   $xms = '256m',

--- a/templates/elasticsearch.in.sh.erb
+++ b/templates/elasticsearch.in.sh.erb
@@ -24,7 +24,6 @@ if [ "x$ES_HEAP_NEWSIZE" != "x" ]; then
     JAVA_OPTS="$JAVA_OPTS -Xmn${ES_HEAP_NEWSIZE}"
 fi
 
-
 <% if @use_original_gc_settings == true -%>
 JAVA_OPTS="$JAVA_OPTS -XX:+UseParNewGC"
 JAVA_OPTS="$JAVA_OPTS -XX:+UseConcMarkSweepGC"
@@ -34,6 +33,16 @@ JAVA_OPTS="$JAVA_OPTS -XX:+UseCMSInitiatingOccupancyOnly"
 <% end -%>
 
 <% if @use_original_gc_settings == false -%>
+# reduce the per-thread stack size
+JAVA_OPTS="$JAVA_OPTS -Xss256k"
+
+# Force the JVM to use IPv4 stack
+# JAVA_OPTS="$JAVA_OPTS -Djava.net.preferIPv4Stack=true"
+
+# Enable aggressive optimizations in the JVM
+#    - Disabled by default as it might cause the JVM to crash
+# JAVA_OPTS="$JAVA_OPTS -XX:+AggressiveOpts"
+
 JAVA_OPTS="$JAVA_OPTS -XX:+UseParNewGC"
 JAVA_OPTS="$JAVA_OPTS -XX:+UseConcMarkSweepGC"
 
@@ -45,10 +54,6 @@ JAVA_OPTS="$JAVA_OPTS -XX:+CMSParallelRemarkEnabled"
 # When running under Java 7
 JAVA_OPTS="$JAVA_OPTS -XX:+UseCondCardMark"
 <% end -%>
-
-
-
-
 # GC logging options -- uncomment to enable
 # JAVA_OPTS="$JAVA_OPTS -XX:+PrintGCDetails"
 # JAVA_OPTS="$JAVA_OPTS -XX:+PrintGCTimeStamps"

--- a/templates/elasticsearch.in.sh.erb
+++ b/templates/elasticsearch.in.sh.erb
@@ -24,16 +24,16 @@ if [ "x$ES_HEAP_NEWSIZE" != "x" ]; then
     JAVA_OPTS="$JAVA_OPTS -Xmn${ES_HEAP_NEWSIZE}"
 fi
 
-# reduce the per-thread stack size
-JAVA_OPTS="$JAVA_OPTS -Xss256k"
 
-# Force the JVM to use IPv4 stack
-# JAVA_OPTS="$JAVA_OPTS -Djava.net.preferIPv4Stack=true"
+<% if @use_original_gc_settings == true -%>
+JAVA_OPTS="$JAVA_OPTS -XX:+UseParNewGC"
+JAVA_OPTS="$JAVA_OPTS -XX:+UseConcMarkSweepGC"
 
-# Enable aggressive optimizations in the JVM
-#    - Disabled by default as it might cause the JVM to crash
-# JAVA_OPTS="$JAVA_OPTS -XX:+AggressiveOpts"
+JAVA_OPTS="$JAVA_OPTS -XX:CMSInitiatingOccupancyFraction=75"
+JAVA_OPTS="$JAVA_OPTS -XX:+UseCMSInitiatingOccupancyOnly"
+<% end -%>
 
+<% if @use_original_gc_settings == false -%>
 JAVA_OPTS="$JAVA_OPTS -XX:+UseParNewGC"
 JAVA_OPTS="$JAVA_OPTS -XX:+UseConcMarkSweepGC"
 
@@ -44,6 +44,10 @@ JAVA_OPTS="$JAVA_OPTS -XX:+CMSParallelRemarkEnabled"
 
 # When running under Java 7
 JAVA_OPTS="$JAVA_OPTS -XX:+UseCondCardMark"
+<% end -%>
+
+
+
 
 # GC logging options -- uncomment to enable
 # JAVA_OPTS="$JAVA_OPTS -XX:+PrintGCDetails"


### PR DESCRIPTION
Since the dawn of our ES cluster, we have a set of customised GC settings. We're not sure exactly what implications they have. Local testing with/without these settings doesn't really indicate any difference between original and our own settings in terms of performance, but it's hard to know how it plays out at a bigger scale.

With this option, we can enable the default GC settings. Plan is to try this out in NetRedux staging first, and if successful, roll out to production.