### PR TITLE
Add ability to set arbitrary attribues to nodes

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -18,6 +18,7 @@ define es(
   $multicast = true,
   $nodedata = true,
   $nodetag = '',
+  $attributes = undef,
   $path_repo = [],
   $spmkey = 'none',
   $enable_flight_recorder = false,

--- a/templates/elasticsearch.yml.erb
+++ b/templates/elasticsearch.yml.erb
@@ -55,6 +55,12 @@ node:
         tag: <%= @nodetag %>
 <% end -%>
 
+<% if @attributes -%>
+  <% @attributes.each do |key, val| -%>
+      <%= key %>: <%= val %>
+  <% end %>
+<% end -%>
+
 indices.cache.filter.size: <%= @indices_cache_filter_size %>
 indices.fielddata.cache.size: <%= @indices_fielddata_cache_size %>
 indices.fielddata.cache.expire: <%= @indices_fielddata_cache_expire %>


### PR DESCRIPTION
Right now, we can only specify "tag" to a node. But elasticsearch supports arbitrary attribute name and values. These can be used for allocation filtering etc.

